### PR TITLE
Update opt_savings_jax.py with latest changes

### DIFF
--- a/bianchi/ref_material/opt_savings_jax_1.py
+++ b/bianchi/ref_material/opt_savings_jax_1.py
@@ -1,6 +1,6 @@
 # # Optimal savings with JAX
 #
-# #### Prepared for the CBC QuantEcon Workshop (September 2022)
+# #### Prepared for the IMF QuantEcon Workshop (March 2024)
 #
 # #### John Stachurski
 #
@@ -15,34 +15,7 @@ import matplotlib.pyplot as plt
 
 # Use 64 bit floats with JAX in order to match NumPy/Numba code
 jax.config.update("jax_enable_x64", True)
-
-def successive_approx(T,                     # Operator (callable)
-                      x_0,                   # Initial condition
-                      tolerance=1e-6,        # Error tolerance
-                      max_iter=10_000,       # Max iteration bound
-                      print_step=25,         # Print at multiples
-                      verbose=False):        
-    x = x_0
-    error = tolerance + 1
-    k = 1
-    while error > tolerance and k <= max_iter:
-        x_new = T(x)
-        error = jnp.max(np.abs(x_new - x))
-        if verbose and k % print_step == 0:
-            print(f"Completed iteration {k} with error {error}.")
-        x = x_new
-        k += 1
-    if error > tolerance:
-        print(f"Warning: Iteration hit upper bound {max_iter}.")
-    elif verbose:
-        print(f"Terminated successfully in {k} iterations.")
-    return x
-
-
-# -
-
-# ##  Primitives and Operators 
-
+    
 # A namedtuple definition for storing parameters and grids
 Model = namedtuple('Model', 
                     ('β', 'R', 'γ', 'w_grid', 'y_grid', 'Q'))
@@ -204,11 +177,6 @@ def R_σ(v, σ, constants, sizes, arrays):
 def get_value(σ, constants, sizes, arrays):
     "Get the value v_σ of policy σ by inverting the linear map R_σ."
 
-    # Unpack 
-    β, R, γ = constants
-    w_size, y_size = sizes
-    w_grid, y_grid, Q = arrays
-
     r_σ = compute_r_σ(σ, constants, sizes, arrays)
 
     # Reduce R_σ to a function in v
@@ -216,6 +184,27 @@ def get_value(σ, constants, sizes, arrays):
 
     return jax.scipy.sparse.linalg.bicgstab(partial_R_σ, r_σ)[0]
 
+## Primitives and Operators 
+def successive_approx_jax(x_0,               # Initial condition
+                        constants,
+                        sizes,
+                        arrays,                 
+                        tolerance=1e-6,        # Error tolerance
+                        max_iter=10_000,       # Max iteration bound
+                        ):        
+
+    def body_fun(k_x_err):
+        k, x, error = k_x_err
+        x_new = T(x, constants, sizes, arrays)
+        error = jnp.max(jnp.abs(x_new - x))
+        return k + 1, x_new, error
+
+    def cond_fun(k_x_err):
+        k, x, error = k_x_err
+        return jnp.logical_and(error > tolerance, k < max_iter)
+
+    k, x, error = jax.lax.while_loop(cond_fun, body_fun, (1, x_0, tolerance + 1))
+    return x
 
 # ## JIT compiled versions
 
@@ -223,23 +212,20 @@ B = jax.jit(B, static_argnums=(2,))
 compute_r_σ = jax.jit(compute_r_σ, static_argnums=(2,))
 T = jax.jit(T, static_argnums=(2,))
 get_greedy = jax.jit(get_greedy, static_argnums=(2,))
-
 get_value = jax.jit(get_value, static_argnums=(2,))
 
 T_σ = jax.jit(T_σ, static_argnums=(3,))
 R_σ = jax.jit(R_σ, static_argnums=(3,))
 
+successive_approx_jax = jax.jit(successive_approx_jax, static_argnums=(2,))
 
 # ##  Solvers
-
 def value_iteration(model, tol=1e-5):
     "Implements VFI."
 
     constants, sizes, arrays = model
-    _T = lambda v: T(v, constants, sizes, arrays)
     vz = jnp.zeros(sizes)
-
-    v_star = successive_approx(_T, vz, tolerance=tol)
+    v_star = successive_approx_jax(vz,constants, sizes, arrays, tol)
     return get_greedy(v_star, constants, sizes, arrays)
 
 def policy_iteration(model):
@@ -267,7 +253,7 @@ def optimistic_policy_iteration(model, tol=1e-5, m=10):
         σ = get_greedy(v, constants, sizes, arrays)
         for _ in range(m):
             v = T_σ(v, σ, constants, sizes, arrays)
-        error = jnp.max(np.abs(v - last_v))
+        error = jnp.max(jnp.abs(v - last_v))
     return get_greedy(v, constants, sizes, arrays)
 
 
@@ -314,7 +300,6 @@ print(out)
 print(f"OPI completed in {elapsed} seconds.")
 
 
-# +
 m_vals = range(5, 3000, 100)
 model = create_consumption_model_jax()
 print("Running Howard policy iteration.")
@@ -348,5 +333,3 @@ ax.set_xlabel("$m$", fontsize=fontsize)
 ax.set_ylabel("time", fontsize=fontsize)
 plt.show()
 # -
-
-


### PR DESCRIPTION
Hi @jstac

This PR includes:

1. Updates in `qe.tauchen` which was breaking on previous version. This PR needs quantecon's latest version.
2. Added `successive_approx_jax`.
3. `bianchi/ref_material/opt_savings_jax_1.py` is the new file that uses `successive_approx_jax`.

To benchmark run:

```bash
% python successive_approx_bench.py 
OMP: Info #276: omp_set_nested routine deprecated, please use omp_set_max_active_levels instead.
Starting VFI.
TOC: Elapsed: 0:00:2.65
VFI with JAX completed in 2.653095006942749 seconds.
TOC: Elapsed: 0:00:6.89
Does previous and current function return same? True
VFI older version completed in 6.892323017120361 seconds.
```

Results on my machine(mac M1 2020) shows that the new version is 3 times faster than previous one.